### PR TITLE
PHP 8.4 Nullable Deprecation Notice

### DIFF
--- a/Model/PaymentMethod/Rma.php
+++ b/Model/PaymentMethod/Rma.php
@@ -72,10 +72,10 @@ class Rma extends \Magento\Payment\Model\Method\AbstractMethod
         \Magento\Payment\Model\Method\Logger $logger,
         OpenPosConfiguration $openPosConfiguration,
         TillSessionManagement $tillSessionManagement,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
-        DirectoryHelper $directory = null
+        ?DirectoryHelper $directory = null
     ) {
         parent::__construct(
             $context,
@@ -117,7 +117,7 @@ class Rma extends \Magento\Payment\Model\Method\AbstractMethod
      * @param \Magento\Quote\Api\Data\CartInterface|null $quote
      * @return bool
      */
-    public function isAvailable(\Magento\Quote\Api\Data\CartInterface $quote = null)
+    public function isAvailable(?\Magento\Quote\Api\Data\CartInterface $quote = null)
     {
         // Check if POS module is enabled
         if(!$this->openPosConfiguration->isEnabled()) {

--- a/Plugin/PaymentMethodFilter.php
+++ b/Plugin/PaymentMethodFilter.php
@@ -25,7 +25,7 @@ class PaymentMethodFilter
         $this->tillSessionManagement = $tillSessionManagement;
     }
 
-    public function afterIsAvailable(MethodInterface $subject, $result, CartInterface $quote = null)
+    public function afterIsAvailable(MethodInterface $subject, $result, ?CartInterface $quote = null)
     {
         if (!$quote) {
             return $result;


### PR DESCRIPTION
* Handles a deprecated nullable warning being thrown in PHP 8.4

Fixes the following error being thrown during checkout on OpenPOS 2.3.1:

> Deprecated: Zero1\OpenPosRma\Model\PaymentMethod\Rma::__construct(): Implicitly marking parameter $resource as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos-rma/Model/PaymentMethod/Rma.php on line 65
Deprecated: Zero1\OpenPosRma\Model\PaymentMethod\Rma::__construct(): Implicitly marking parameter $resourceCollection as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos-rma/Model/PaymentMethod/Rma.php on line 65 
Deprecated: Zero1\OpenPosRma\Model\PaymentMethod\Rma::__construct(): Implicitly marking parameter $directory as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos-rma/Model/PaymentMethod/Rma.php on line 65
Deprecated: Zero1\OpenPosRma\Model\PaymentMethod\Rma::isAvailable(): Implicitly marking parameter $quote as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/zero1/open-pos-rma/Model/PaymentMethod/Rma.php on line 120 